### PR TITLE
Adding EithErrDo module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ This makes signatures shorter and emphasises that **`IOEither` is just a synonym
 
 ---
 
+## Two modules: EitherDo and EithErrDo
+
+The library provides **two main entry points**:
+
+- **`EitherDo`** — the base module, easiest for new users who just want ergonomic `IO (Either e a)` code.  
+- **`EithErrDo`** — a stricter variant that encourages using a dedicated `Error` type class for error management.  
+
+👉 New users may start with `EitherDo`, but if you plan to use this library for **serious error handling**, we recommend moving to `EithErrDo`.
+
+---
+
 ## Quick taste
 
 ```haskell

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The library provides **two main entry points**:
 
 ---
 
-## Quick taste
+## Quick taste (EitherDo)
 
 ```haskell
 {-# LANGUAGE QualifiedDo #-}
@@ -56,6 +56,41 @@ pipeline = E.do
   _ <- E.traverseE_ doOne [1..n]
   E.ok ()
 ```
+
+---
+
+## Quick taste (EithErrDo)
+
+```haskell
+{-# LANGUAGE QualifiedDo #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+import qualified EithErrDo.Edo as E
+import GHC.Generics (Generic)
+
+-- Define an error type that is an instance of the Error class
+data MyError
+  = MissingConfig
+  | ParseFail
+  | DbError String
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (E.Error)
+
+fetchConfig :: E.IOEither MyError Int
+fetchConfig = pure (Right 3)
+
+doOne :: Int -> E.IOEither MyError ()
+doOne n = if n < 5 then E.ok () else E.bad (DbError "too big")
+
+pipeline :: E.IOEither MyError ()
+pipeline = E.do
+  n <- fetchConfig
+  _ <- E.traverseE_ doOne [1..n]
+  E.ok ()
+```
+
+This version enforces that your error type implements the `Error` type class, encouraging consistency and better error management.
 
 ---
 

--- a/edo.cabal
+++ b/edo.cabal
@@ -20,7 +20,9 @@ common warnings
 
 library
     import:           warnings
-    exposed-modules:  EitherDo.Edo
+    exposed-modules:  
+        EitherDo.Edo
+        EithErrDo.Edo
     other-modules:
         EitherDo.Core
         EitherDo.Collect
@@ -30,7 +32,18 @@ library
         EitherDo.Kleisli
         EitherDo.Lift
         EitherDo.Res
-    build-depends:    base ^>=4.19.2.0
+        EithErrDo.Core
+        EithErrDo.Collect
+        EithErrDo.Branch
+        EithErrDo.Error
+        EithErrDo.Except
+        EithErrDo.Kleisli
+        EithErrDo.Lift
+        EithErrDo.Res
+        EithErrDo.Types
+    build-depends:      
+        base ^>=4.19.2.0
+      , text
     hs-source-dirs:   src
     if impl(ghc >= 9.10)
       default-language: GHC2024

--- a/src/EithErrDo/Branch.hs
+++ b/src/EithErrDo/Branch.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module EithErrDo.Branch
+  ( whenE, unlessE, tapE
+  ) where
+
+import EithErrDo.Types   (IOEither, Error(..)) 
+import qualified EitherDo.Branch  as Br ( whenE, unlessE, tapE )
+import Prelude (IO, Bool(..))
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text)
+-- >>> import qualified Data.Text as T
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Run the action when the predicate is 'True'; otherwise succeed with @()@.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.whenE True (E.ok "ignored" :: E.IOEither Err String)
+-- Right ()
+-- >>> E.whenE True (E.bad (ParseErr "returned") :: E.IOEither Err String)
+-- Left (ParseErr "returned")
+-- >>> E.whenE False (E.bad (NotFound "ignored") ::  E.IOEither Err String)
+-- Right ()
+whenE :: Error e => forall a. Bool -> IOEither e a -> IOEither e ()
+whenE = Br.whenE
+
+-- | Run the action when the predicate is 'False'; otherwise succeed with @()@.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.unlessE False (E.ok 1 :: E.IOEither Err Int)
+-- Right ()
+-- >>> E.unlessE False (E.bad (Bug "error") :: E.IOEither Err Int)
+-- Left (Bug "error")
+-- >>> E.unlessE True (E.bad (ParseErr "error") :: E.IOEither Err Int)
+-- Right ()
+unlessE :: Error e => forall a. Bool -> IOEither e a -> IOEither e ()
+unlessE = Br.unlessE
+
+-- | On success, perform an 'IO' side effect with the value, then return it.
+-- @since 0.1.0
+-- Useful for logging/metrics without breaking the flow.
+--
+-- ==== __Examples__
+-- >>> let side _ = pure () :: IO () -- stand-in for logging
+-- >>> E.tapE side (E.ok 7 :: E.IOEither Err Int)
+-- Right 7
+-- >>> E.tapE side (E.bad (NotFound "error") :: E.IOEither Err Int)
+-- Left (NotFound "error")
+tapE :: Error e => forall a. (a -> IO ()) -> IOEither e a -> IOEither e a
+tapE = Br.tapE

--- a/src/EithErrDo/Collect.hs
+++ b/src/EithErrDo/Collect.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE QualifiedDo       #-}
+
+module EithErrDo.Collect
+  ( sequenceE, traverseE, forE, sequenceE_, traverseE_, forE_
+  ) where
+
+import EithErrDo.Types   (IOEither, Error(..)) 
+import qualified EitherDo.Collect as Cl ( sequenceE, traverseE, forE, sequenceE_, traverseE_, forE_ )
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text)
+-- >>> import qualified Data.Text as T
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Sequence a list of @IOEither@, short-circuiting on the first error.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.sequenceE [E.ok 1, E.ok 2, E.ok 3 :: E.IOEither Err Int]
+-- Right [1,2,3]
+-- >>> E.sequenceE [E.ok 1, E.bad (Bug "error1"), E.ok 2, E.bad (NotFound "error2") :: E.IOEither Err Int]
+-- Left (Bug "error1")
+sequenceE :: Error e => forall a. [IOEither e a] -> IOEither e [a]
+sequenceE = Cl.sequenceE
+
+-- | Traverse with an @IOEither@ effect, short-circuiting on error.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f n = if n > 0 then E.ok (n*2) else E.bad (Bug "error") :: E.IOEither Err Int
+-- >>> E.traverseE f [1,2,3]
+-- Right [2,4,6]
+-- >>> E.traverseE f [1,0,2]
+-- Left (Bug "error")
+traverseE :: Error e => forall x a. (x -> IOEither e a) -> [x] -> IOEither e [a]
+traverseE = Cl.traverseE
+
+-- | Flipped 'traverseE' for pipeline style.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f n = if n > 0 then E.ok (n*2) else E.bad (NotFound "error") :: E.IOEither Err Int
+-- >>> E.forE [1,2,3] f
+-- Right [2,4,6]
+-- >>> E.forE [1,0,2] f
+-- Left (NotFound "error")
+forE :: Error e => forall x a. [x] -> (x -> IOEither e a) -> IOEither e [a]
+forE = Cl.forE
+
+-- | Like 'sequenceE' but discards results.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.sequenceE_ [E.ok 1, E.ok 2, E.ok 3 :: E.IOEither Err Int]
+-- Right ()
+-- >>> E.sequenceE_ [E.ok 1, E.bad (ParseErr "error1"), E.ok 2, E.bad (Bug "error2") :: E.IOEither Err Int]
+-- Left (ParseErr "error1")
+sequenceE_ :: Error e => forall a. [IOEither e a] -> IOEither e ()
+sequenceE_ = Cl.sequenceE_
+
+-- | Flipped 'traverseE_' for pipeline style.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f n = if n > 0 then E.ok (n*2) else E.bad (Bug "error") :: E.IOEither Err Int
+-- >>> E.forE_ [1,2,3] f
+-- Right ()
+-- >>> E.forE_ [1,0,2] f
+-- Left (Bug "error")
+traverseE_ :: Error e => forall x a. (x -> IOEither e a) -> [x] -> IOEither e ()
+traverseE_ = Cl.traverseE_
+
+-- | Flipped 'traverseE_' for pipeline style.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f n = if n > 0 then E.ok (n*2) else E.bad (ParseErr "error") :: E.IOEither Err Int
+-- >>> E.forE_ [1,2,3] f
+-- Right ()
+-- >>> E.forE_ [1,0,2] f
+-- Left (ParseErr "error")
+forE_ :: Error e => forall x a. [x] -> (x -> IOEither e a) -> IOEither e ()
+forE_ = Cl.forE_

--- a/src/EithErrDo/Core.hs
+++ b/src/EithErrDo/Core.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE QualifiedDo       #-}
+
+module EithErrDo.Core
+  ( (>>=), (=<<), (>>), (|>)
+  , return, ok, bad, onRight
+  ) where
+
+import qualified EitherDo.Core   as Cr (bad, ok, onRight, return, (=<<), (>>),
+                                        (>>=), (|>))
+import           EithErrDo.Types
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text)
+-- >>> import qualified Data.Text as T
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Qualified-@do@ bind for @IOEither@.
+--
+-- Lets you write @E.do@ blocks that short-circuit on @Left@.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.do x <- E.ok (2 :: Int) :: E.IOEither Err Int; E.ok (x + 1)
+-- Right 3
+-- >>> E.do _ <- E.bad (Bug "boom") :: E.IOEither Err Int; E.ok (99 :: Int)
+-- Left (Bug "boom")
+(>>=) :: Error e => forall a b. IOEither e a -> (a -> IOEither e b) -> IOEither e b
+(>>=) = (Cr.>>=)
+
+-- | Reverse bind
+--
+-- @since 0.1.0
+--
+(=<<) :: Error e => forall a b. (a -> IOEither e b) -> IOEither e a -> IOEither e b
+(=<<) = (Cr.=<<)
+
+-- | Sequencing for @IOEither@; discards the first result.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.do E.ok () >> E.ok "x" :: E.IOEither Err String
+-- Right "x"
+-- >>> E.do E.bad (NotFound "e") >> E.ok "x" :: E.IOEither Err String
+-- Left (NotFound "e")
+(>>) :: Error e => forall a b. IOEither e a -> IOEither e b -> IOEither e b
+(>>) = (Cr.>>)
+
+-- | Pipeline sugar: same behavior as >>=.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f x = if x > 0 then E.ok (x*2) else E.bad (NotFound "neg") :: E.IOEither Err Int
+-- >>> (E.ok 3 :: E.IOEither Err Int) E.|> f
+-- Right 6
+-- >>> (E.ok 0 :: E.IOEither Err Int) E.|> f
+-- Left (NotFound "neg")
+(|>) :: Error e => forall a b. IOEither e a -> (a -> IOEither e b) -> IOEither e b
+(|>) = (Cr.|>)
+
+-- | Pipe the @Right@ value into a continuation; if @Left@, propagate it.
+-- @since 0.1.0
+--
+-- Synonym of '(>>=)' specialized to readability in pipelines.
+onRight :: Error e => forall a b. IOEither e a -> (a -> IOEither e b) -> IOEither e b
+onRight = Cr.onRight
+
+-- | Lift a pure value into @Right@.
+-- @since 0.1.0
+--
+return :: Error e => forall a. a -> IOEither e a
+return = Cr.return
+
+-- | Alias for 'return'.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.ok "hi" :: E.IOEither Err String
+-- Right "hi"
+ok :: Error e => forall a. a -> IOEither e a
+ok = Cr.ok
+
+-- | Construct a failed computation.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.bad (ParseErr "nope") :: E.IOEither Err Int
+-- Left (ParseErr "nope")
+bad :: Error e => forall a. e -> IOEither e a
+bad = Cr.bad

--- a/src/EithErrDo/Edo.hs
+++ b/src/EithErrDo/Edo.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE QualifiedDo       #-}
+
+{-|
+Module      : EithErrDo.Edo
+Description : Qualified do-notation and helpers for IO (Either e a)
+License     : BSD-3-Clause
+Maintainer  : nj.cooke@outlook.com
+Stability   : experimental
+Portability : portable
+
+Write ergonomic code in the @IO (Either e a)@ style using @QualifiedDo@.  
+
+Instead of juggling `ExceptT e IO` or nested case-expressions, you write
+straight-line code and let failures short-circuit automatically.
+
+Here is a complete example:
+
+@
+{-# LANGUAGE QualifiedDo, OverloadedStrings, DerivingVia #-}
+
+import qualified EithErrDo.Edo as E
+import Data.Text (Text)
+import System.Environment (lookupEnv)
+
+-- A small error type with 'Error' instance via 'Show'
+data Err = ParseErr Text | NotFound Text
+  deriving (Eq, Show)
+deriving via (E.ViaShow Err) instance E.Error Err
+
+-- A config reader in the 'IOEither Err' style
+readPort :: E.IOEither Err Int
+readPort = E.do
+  m <- E.hoistEither (maybe (Left (NotFound "PORT")) Right)
+         =<< E.ok =<< lookupEnv "PORT"
+  n <- E.hoistEither ParseErr (readEither m)
+  E.ok n
+
+-- Example program using the API
+main :: IO ()
+main = do
+  r <- readPort
+  case r of
+    Left e  -> putStrLn ("config error: " <> show e)
+    Right n -> putStrLn ("starting on port " <> show n)
+@
+
+The above shows:
+
+  * defining a custom error type (`Err`) and deriving `Error` via 'Show'
+  * using @QualifiedDo@ with `E.do`
+  * combining IO actions and error checks without extra boilerplate
+  * clean short-circuiting on the first error
+
+@since 0.1.0
+-}
+
+module EithErrDo.Edo
+  ( -- * Types
+    IOEither, Error(..), ViaException(..), ViaShow(..)
+    -- * Core
+  , (>>=), (=<<), (>>), return, ok, bad, (|>), onRight
+    -- * Lifting & conversions
+  , hoistEither, fromMaybeE, guardE
+    -- * Error mapping & recovery
+  , mapErrorE, recoverE, orElse
+    -- * Branching / side effects
+  , whenE, unlessE, tapE
+    -- * Collecting results
+  , sequenceE, traverseE, forE, sequenceE_, traverseE_, forE_
+    -- * Resource-safety
+  , finallyE, bracketE
+    -- * Exceptions interop
+  , tryE, tryAnyE
+    -- * Kleisli
+  , (>=>), (<=<)
+  ) where
+
+import EithErrDo.Core    ( return, ok, bad, onRight, (>>=), (=<<), (>>), (|>) ) 
+import EithErrDo.Lift    ( hoistEither, fromMaybeE, guardE )
+import EithErrDo.Error   ( mapErrorE, recoverE, orElse )
+import EithErrDo.Branch  ( whenE, unlessE, tapE )
+import EithErrDo.Collect ( sequenceE, traverseE, forE, sequenceE_, traverseE_, forE_ )
+import EithErrDo.Res     ( finallyE, bracketE )
+import EithErrDo.Except  ( tryE, tryAnyE )
+import EithErrDo.Kleisli ( (>=>), (<=<) )
+import EithErrDo.Types   ( IOEither, Error(..), ViaException(..), ViaShow(..) )
+

--- a/src/EithErrDo/Error.hs
+++ b/src/EithErrDo/Error.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module EithErrDo.Error
+  ( mapErrorE, recoverE, orElse
+  ) where
+
+import EithErrDo.Types   (IOEither, Error(..)) 
+import qualified EitherDo.Error   as Er ( mapErrorE, recoverE, orElse )
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text, toUpper)
+-- >>> import qualified Data.Text as T
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Map the error type of an 'IOEither'.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.mapErrorE (\(ParseErr t) -> ParseErr (toUpper t)) (E.bad (ParseErr "boom") :: E.IOEither Err Int)
+-- Left (ParseErr "BOOM")
+-- >>> E.mapErrorE (\(ParseErr t) -> ParseErr (toUpper t)) (E.ok 5 :: E.IOEither Err Int)
+-- Right 5
+mapErrorE :: (Error e, Error e') => forall a. (e -> e') -> IOEither e a -> IOEither e' a
+mapErrorE = Er.mapErrorE
+
+-- | Handle a failure by providing a recovery action.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.recoverE (E.bad (Bug "error")) (\_ -> E.ok "yes") :: E.IOEither Err String
+-- Right "yes"
+-- >>> E.recoverE (E.ok "ok") (\_ -> E.ok "yes") :: E.IOEither Err String
+-- Right "ok"
+recoverE :: Error e => forall a. IOEither e a -> (e -> IOEither e a) -> IOEither e a
+recoverE = Er.recoverE
+
+-- | Try the first computation; if it fails, run the alternative.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.orElse (E.bad (Bug "x")) (E.ok "alt") :: E.IOEither Err String
+-- Right "alt"
+-- >>> E.orElse (E.ok "ok") (E.bad (ParseErr "never")) :: E.IOEither Err String
+-- Right "ok"
+orElse :: Error e => forall a. IOEither e a -> IOEither e a -> IOEither e a
+orElse = Er.orElse

--- a/src/EithErrDo/Except.hs
+++ b/src/EithErrDo/Except.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module EithErrDo.Except
+  ( tryE, tryAnyE
+  ) where
+
+import EithErrDo.Types   (IOEither, Error(..)) 
+import qualified EitherDo.Except  as Ex ( tryE, tryAnyE )
+import Prelude (IO)
+import Control.Exception (Exception, SomeException)
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text, toUpper)
+-- >>> import qualified Data.Text as T
+-- >>> import Data.IORef
+-- >>> import qualified Control.Exception as X
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Catch a specific exception from an 'IO' action and map it to your error.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.tryE (\(_ :: X.IOException) -> (Bug "io")) (pure "ok")
+-- Right "ok"
+--
+-- >>> E.tryE (\(_ :: X.IOException) -> (Bug "io")) (X.throwIO (userError "nope") :: IO ())
+-- Left (Bug "io")
+--
+-- Works smoothly inside an E.do block:
+---
+-- ==== __Examples__
+-- >>> E.do n <- E.tryE (\(_ :: X.IOException) -> (Bug t"io")) (pure (3 :: Int))
+-- ...      E.ok (n + 1)
+-- Right 4
+tryE :: Error e => forall ex a. Exception ex => (ex -> e) -> IO a -> IOEither e a
+tryE = Ex.tryE
+
+-- | Catch any exception (use with care) and map to your error type.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.tryAnyE (const (NotFound "boom")) (pure (99 :: Int))
+-- Right 99
+--
+-- >>> E.tryAnyE (const (NotFound "boom")) (X.throwIO (userError "oh no") :: IO Int)
+-- Left (NotFound "boom")
+--
+-- Equivalent to 'tryE' specialized to 'SomeException':
+---
+-- ==== __Examples__
+-- >>> let f = const (Bug "x") :: X.SomeException -> String
+-- >>> E.tryAnyE f (pure (1 :: Int))
+-- Right 1
+-- >>> E.tryE f (pure (1 :: Int))
+-- Right 1
+tryAnyE :: Error e => forall a. (SomeException -> e) -> IO a -> IOEither e a
+tryAnyE = Ex.tryAnyE

--- a/src/EithErrDo/Kleisli.hs
+++ b/src/EithErrDo/Kleisli.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module EithErrDo.Kleisli
+  ( (>=>), (<=<)
+  ) where
+
+import EithErrDo.Types (IOEither, Error(..)) 
+import qualified EitherDo.Kleisli as Kl ( (>=>), (<=<) )
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text, toUpper)
+-- >>> import qualified Data.Text as T
+-- >>> import Data.IORef
+-- >>> import qualified Control.Exception as X
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Kleisli composition for @a -> IOEither e b@.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f x = if x > 0 then E.ok (x+1) else E.bad (ParseErr "neg") :: E.IOEither Err Int
+-- >>> let g y = if even y then E.ok (show y) else E.bad (Bug "odd") :: E.IOEither Err String
+-- >>> (f E.>=> g) 3
+-- Right "4"
+-- >>> (f E.>=> g) 2
+-- Left (Bug "odd")
+-- >>> (f E.>=> g) (-1)
+-- Left (ParseErr "neg")
+(>=>) :: Error e => forall a b c. (a -> IOEither e b) -> (b -> IOEither e c) -> a -> IOEither e c
+(>=>) = (Kl.>=>)
+
+-- | Reverse Kleisli composition.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> let f x = if x > 0 then E.ok (x+1) else E.bad (ParseErr "neg") :: E.IOEither Err Int
+-- >>> let g y = if even y then E.ok (show y) else E.bad (Bug "odd") :: E.IOEither Err String
+-- >>> (g E.<=< f) 3
+-- Right "4"
+-- >>> (g E.<=< f) 2
+-- Left (Bug "odd")
+-- >>> (g E.<=< f) (-1)
+-- Left (ParseErr "neg")
+(<=<) :: Error e => forall b c a. (b -> IOEither e c) -> (a -> IOEither e b) -> a -> IOEither e c
+(<=<) = (Kl.<=<)

--- a/src/EithErrDo/Lift.hs
+++ b/src/EithErrDo/Lift.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module EithErrDo.Lift
+  ( hoistEither, fromMaybeE, guardE
+  ) where
+
+import EithErrDo.Types   (IOEither, Error) 
+import qualified EitherDo.Lift    as Li ( hoistEither, fromMaybeE, guardE )
+import Prelude (Either(..), Maybe(..), Bool(..), ($))
+import Data.Bifunctor (first)
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text, toUpper)
+-- >>> import Data.IORef
+-- >>> import qualified Control.Exception as X
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Lift a pure 'Either' into 'IOEither' you must provide something of the kind Error e.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.hoistEither Bug (Right (7 :: Int))
+-- Right 7
+-- >>> E.hoistEither Bug (Left "err" :: Either Text Int)
+-- Left (Bug "err")
+hoistEither :: Error e => forall a. (e' -> e) -> Either e' a -> IOEither e a
+hoistEither err eith = Li.hoistEither $ first err eith
+
+-- | Convert a 'Maybe' to 'IOEither', providing an error for 'Nothing'.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.fromMaybeE (Bug "none") (Just 'x')
+-- Right 'x'
+-- >>> E.fromMaybeE (Bug "none") (Nothing :: Maybe Int)
+-- Left (Bug "none")
+fromMaybeE :: Error e => forall a. e -> Maybe a -> IOEither e a
+fromMaybeE = Li.fromMaybeE
+
+-- | Succeed with @()@ when predicate holds; otherwise fail with the error.
+-- @since 0.1.0
+--
+-- ==== __Examples__
+-- >>> E.guardE True (ParseErr "err")
+-- Right ()
+-- >>> E.guardE False (NotFound "err")
+-- Left (NotFound "err")
+guardE :: Error e => Bool -> e -> IOEither e ()
+guardE = Li.guardE

--- a/src/EithErrDo/Res.hs
+++ b/src/EithErrDo/Res.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module EithErrDo.Res
+  ( finallyE, bracketE
+  ) where
+
+import qualified EitherDo.Res    as Re (bracketE, finallyE)
+import           EithErrDo.Types (Error (..), IOEither)
+import           Prelude         (IO)
+
+-- $setup
+-- >>> import Prelude hiding ((>>=), return, (>>), (>=>))
+-- >>> import qualified EithErrDo.Edo as E
+-- >>> import Data.Text (Text, toUpper)
+-- >>> import Data.IORef
+-- >>> import qualified Control.Exception as X
+-- >>> :set -XQualifiedDo
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XDerivingVia
+--
+-- A tiny error type for all examples.
+-- We derive Show and then use `ViaShow` to satisfy `E.Error`.
+-- >>> :{
+-- data Err = ParseErr Text | NotFound Text | Bug Text
+--   deriving (Eq, Show)
+-- deriving via (E.ViaShow Err) instance E.Error Err
+-- :}
+
+-- | Ensure a finaliser runs after the computation (success or failure).
+-- @since 0.1.0
+--
+-- Runs the finalizer even on 'Left', and preserves the original result.
+---
+-- ==== __Examples__
+-- >>> let testFinallyRight = do
+-- ...       r   <- newIORef ([] :: [String])
+-- ...       res <- E.finallyE (E.ok "X" :: E.IOEither Err ()) (modifyIORef' r ("fin":))
+-- ...       logs <- readIORef r
+-- ...       pure (res, logs)
+-- >>> testFinallyRight
+-- (Right "X",["fin"])
+--
+-- >>> let testFinallyLeft = do
+-- ...       r   <- newIORef ([] :: [String])
+-- ...       res <- E.finallyE (E.bad (Bug "e") :: E.IOEither Err ()) (modifyIORef' r ("fin":))
+-- ...       logs <- readIORef r
+-- ...       pure (res, logs)
+-- >>> testFinallyLeft
+-- (Left (Bug "e"),["fin"])
+finallyE :: Error e => forall a. IOEither e a -> IO () -> IOEither e a
+finallyE = Re.finallyE
+
+-- | Acquire / use / release with @IOEither@ semantics.
+-- @since 0.1.0
+--
+-- If acquisition fails, 'release' is not called. If use runs, 'release' runs
+-- afterwards regardless of success or failure.
+--
+-- Successful acquire + use ⇒ release runs once:
+---
+-- ==== __Examples__
+-- >>> let testBracketOK = do
+-- ...       logRef <- newIORef ([] :: [String])
+-- ...       let acquire   = modifyIORef' logRef ("acq":) >> E.ok "R"
+-- ...           release a = modifyIORef' logRef (("rel:"<>a):)
+-- ...           use _     = modifyIORef' logRef ("use":) >> E.ok "done"
+-- ...       res  <- E.bracketE acquire release use
+-- ...       logs <- readIORef logRef
+-- ...       pure (res, logs)
+-- >>> testBracketOK
+-- (Right "done",["rel:R","use","acq"])
+--
+-- Successful acquire + failing use ⇒ release still runs:
+--
+-- >>> let testBracketUseFail = do
+-- ...       logRef <- newIORef ([] :: [String])
+-- ...       let acquire   = modifyIORef' logRef ("acq":) >> E.ok "R"
+-- ...           release a = modifyIORef' logRef (("rel:"<>a):)
+-- ...           use _     = modifyIORef' logRef ("useBad":) >> E.bad (ParseErr "e")
+-- ...       res  <- E.bracketE acquire release use
+-- ...       logs <- readIORef logRef
+-- ...       pure (res, logs)
+-- >>> testBracketUseFail
+-- (Left (ParseErr "e"),["rel:R","useBad","acq"])
+--
+-- Failing acquire ⇒ release is not called:
+--
+-- >>> let testBracketAcquireFail = do
+-- ...       logRef <- newIORef ([] :: [String])
+-- ...       let acquire   = modifyIORef' logRef ("acqFail":) >> E.bad (Bug "fail")
+-- ...           release a = modifyIORef' logRef (("rel:"<>a):)
+-- ...           use _     = modifyIORef' logRef ("use?":) >> E.ok ()
+-- ...       res  <- E.bracketE acquire release use
+-- ...       logs <- readIORef logRef
+-- ...       pure (res, logs)
+-- >>> testBracketAcquireFail
+-- (Left (Bug "fail"),["acqFail"])
+bracketE :: Error e => forall a b. IOEither e a -> (a -> IO ()) -> (a -> IOEither e b) -> IOEither e b
+bracketE = Re.bracketE

--- a/src/EithErrDo/Types.hs
+++ b/src/EithErrDo/Types.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE QualifiedDo       #-}
+
+module EithErrDo.Types
+  ( IOEither, Error(..), ViaShow(..), ViaException(..)
+  ) where
+
+import           Control.Exception (Exception (displayException))
+import           Data.Text
+import           EitherDo.Core     (IOEither)
+import           Prelude           (Show, show)
+
+{-|
+
+This module defines the lightweight `Error` class used across the edo API,
+together with two small adapters that let you reuse existing instances:
+
+* 'ViaShow'      — lift any @Show e@ to @Error e@
+* 'ViaException' — lift any @Exception e@ to @Error e@
+
+Typical usage with your own error type:
+
+@
+data Err = ParseErr Text | NotFound Text | Bug Text
+  deriving (Eq, Show)
+
+deriving via (ViaShow Err) instance Error Err
+@
+
+Or, if you already have an exception type:
+
+@
+newtype Boom = Boom Text
+  deriving (Show)
+instance Exception Boom
+
+deriving via (ViaException Boom) instance Error Boom
+@
+
+With these in place, all edo combinators that require @Error e@ will work
+with your custom errors, while keeping display/formatting concerns decoupled.
+-}
+
+class Error e where
+  displayError :: e -> Text
+
+-- | 'ViaShow'      — lift any @Show e@ to @Error e@
+--
+-- @since 0.1.0
+--
+newtype ViaShow e = ViaShow e
+instance Show e => Error (ViaShow e) where
+  displayError (ViaShow e) = pack (show e)
+
+-- | 'ViaException' — lift any @Exception e@ to @Error e@
+--
+-- @since 0.1.0
+--
+newtype ViaException e = ViaException e
+instance Exception e => Error (ViaException e) where
+  displayError (ViaException e) = pack (displayException e)

--- a/src/EitherDo/Core.hs
+++ b/src/EitherDo/Core.hs
@@ -57,6 +57,7 @@ type IOEither e a = IO (Either e a)
 --
 (=<<) :: (a -> IOEither e b) -> IOEither e a -> IOEither e b
 (=<<) = flip (>>=)
+
 -- | Sequencing for @IOEither@; discards the first result.
 -- @since 0.1.0
 --
@@ -67,13 +68,6 @@ type IOEither e a = IO (Either e a)
 -- Left "e"
 (>>) :: IOEither e a -> IOEither e b -> IOEither e b
 m1 >> m2 = m1 >>= const m2
-
--- | Pipe the @Right@ value into a continuation; if @Left@, propagate it.
--- @since 0.1.0
---
--- Synonym of '(>>=)' specialized to readability in pipelines.
-onRight :: IOEither e a -> (a -> IOEither e b) -> IOEither e b
-onRight io f = io P.>>= either (pure . Left) f
 
 -- | Pipeline sugar: same behavior as >>=.
 -- @since 0.1.0
@@ -87,6 +81,13 @@ onRight io f = io P.>>= either (pure . Left) f
 (|>) :: IOEither e a -> (a -> IOEither e b) -> IOEither e b
 (|>) = onRight
 infixr 0 |>
+
+-- | Pipe the @Right@ value into a continuation; if @Left@, propagate it.
+-- @since 0.1.0
+--
+-- Synonym of '(>>=)' specialized to readability in pipelines.
+onRight :: IOEither e a -> (a -> IOEither e b) -> IOEither e b
+onRight io f = io P.>>= either (pure . Left) f
 
 -- | Lift a pure value into @Right@.
 -- @since 0.1.0

--- a/src/EitherDo/Lift.hs
+++ b/src/EitherDo/Lift.hs
@@ -20,7 +20,6 @@ import EitherDo.Core
 -- >>> import qualified Control.Exception as X
 -- >>> :set -XQualifiedDo
 
-
 -- | Lift a pure 'Either' into 'IOEither'.
 -- @since 0.1.0
 --


### PR DESCRIPTION
Acts as a wrapper constraining the functions so the `e` in `IOEither e a` has to be of the type class Error e.